### PR TITLE
chore: Fixes to update.sh

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 -e .
 
 # dev
-openapi-python-client>=0.21.5
+openapi-python-client==0.21.5
 pre-commit
 mypy
 ruff

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -91,3 +91,5 @@ rm -rf tmp
 cat scripts/preserve_files.txt | while read entry; do
     git checkout HEAD -- $entry
 done
+
+pre-commit run --all-files


### PR DESCRIPTION
 * Pin version of api-generator to make generated files consistent between different dev environments.
 * Run pre-commit hook to re-add license as part of the script. Without that the script generates massive noise and it is very hard to guess that you need to commit all those unwanted changes in order to get rid of them.