### PR TITLE
feat: Add new exception raised on API key being rejected by the backend.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ attrs = ">=21.3.0"
 python-dateutil = "^2.8.0"
 PyJWT = "^2.0.0"
 protobuf = ">=3.19.6,<6"
-backoff = "^2.2.1"
 
 [tool.poetry]
 name = "neptune-api"

--- a/src/neptune_api/auth_helpers.py
+++ b/src/neptune_api/auth_helpers.py
@@ -34,7 +34,12 @@ def exchange_api_key(client: Client, credentials: Credentials) -> OAuthToken:
         raise ApiKeyRejectedError()
 
     token_data = response.parsed
-    if response.status_code != 200 or not token_data or isinstance(token_data, Error):
+    if isinstance(token_data, Error):
+        raise UnableToExchangeApiKeyError(
+            reason=f"Unexpected response from Neptune API: HTTP {response.status_code} ({token_data.message})"
+        )
+
+    if response.status_code != 200 or not token_data:
         raise UnableToExchangeApiKeyError(reason=f"Unexpected response from Neptune API: HTTP {response.status_code}")
 
     return OAuthToken.from_tokens(access=token_data.access_token, refresh=token_data.refresh_token)

--- a/src/neptune_api/auth_helpers.py
+++ b/src/neptune_api/auth_helpers.py
@@ -15,27 +15,26 @@
 
 __all__ = ["exchange_api_key"]
 
-from typing import Union
-
 from neptune_api import Client
 from neptune_api.api.backend import exchange_api_token
 from neptune_api.credentials import Credentials
-from neptune_api.errors import UnableToExchangeApiKeyError
-from neptune_api.models import (
-    Error,
-    NeptuneOauthToken,
+from neptune_api.errors import (
+    ApiKeyRejectedError,
+    UnableToExchangeApiKeyError,
 )
+from neptune_api.models import Error
 from neptune_api.types import OAuthToken
 
 
 def exchange_api_key(client: Client, credentials: Credentials) -> OAuthToken:
-    token_data: Union[NeptuneOauthToken, None, Error] = exchange_api_token.sync(
-        client=client, x_neptune_api_token=credentials.api_key
-    )
+    response = exchange_api_token.sync_detailed(client=client, x_neptune_api_token=credentials.api_key)
 
-    if isinstance(token_data, Error):
-        raise UnableToExchangeApiKeyError(reason=str(token_data.message))
-    if not token_data:
-        raise UnableToExchangeApiKeyError()
+    # HTTP 401 is an indicator that the API token is rejected by the server
+    if response.status_code == 401:
+        raise ApiKeyRejectedError()
+
+    token_data = response.parsed
+    if response.status_code != 200 or not token_data or isinstance(token_data, Error):
+        raise UnableToExchangeApiKeyError(reason=f"Unexpected response from Neptune API: HTTP {response.status_code}")
 
     return OAuthToken.from_tokens(access=token_data.access_token, refresh=token_data.refresh_token)

--- a/src/neptune_api/client.py
+++ b/src/neptune_api/client.py
@@ -28,7 +28,6 @@ from typing import (
     Union,
 )
 
-import backoff
 import httpx
 from attrs import (
     define,
@@ -387,7 +386,6 @@ class NeptuneAuthenticator(httpx.Auth):
         except Exception as e:
             raise UnableToRefreshTokenError("Unable to refresh token") from e
 
-    @backoff.on_exception(backoff.expo, Exception, max_time=30, max_tries=3)
     def _refresh_token(self) -> None:
         with self.__LOCK:
             if self._token is not None:

--- a/src/neptune_api/client.py
+++ b/src/neptune_api/client.py
@@ -398,8 +398,11 @@ class NeptuneAuthenticator(httpx.Auth):
         try:
             if self._token is None or self._token.is_expired:
                 self._refresh_token()
+        # Don't reset the token on network errors. Raise them immediately for the user to retry.
+        except httpx.RequestError:
+            raise
+        # On any other error reset the token to None to force a new token retrieval
         except Exception:
-            # Reset the token to None to force a new token retrieval
             self._token = None
             self._refresh_token()
 

--- a/src/neptune_api/errors.py
+++ b/src/neptune_api/errors.py
@@ -19,6 +19,7 @@ __all__ = [
     "UnexpectedStatus",
     "InvalidApiTokenException",
     "UnableToExchangeApiKeyError",
+    "ApiKeyRejectedError",
     "UnableToDeserializeApiKeyError",
     "UnableToRefreshTokenError",
 ]
@@ -44,10 +45,18 @@ class InvalidApiTokenException(Exception):
 
 
 class UnableToExchangeApiKeyError(Exception):
-    """Raised when the API key exchange fails"""
+    """Raised when the API key exchange fails for any reason other than the API key being
+    explicitly rejected by the server"""
 
     def __init__(self, reason: str = "Unknown") -> None:
         super().__init__(f"Unable to exchange API key. Reason: {reason}")
+
+
+class ApiKeyRejectedError(Exception):
+    """Raised when the backend rejects an API key because of it being unknown or expired"""
+
+    def __init__(self) -> None:
+        super().__init__("Your API key was rejected by the Neptune backend because it is either unknown or expired.")
 
 
 class UnableToDeserializeApiKeyError(Exception):

--- a/tests/unit/test_token_factory.py
+++ b/tests/unit/test_token_factory.py
@@ -2,7 +2,11 @@ import pytest
 
 from neptune_api import Client
 from neptune_api.auth_helpers import exchange_api_key
-from neptune_api.errors import UnableToExchangeApiKeyError
+from neptune_api.errors import (
+    ApiKeyRejectedError,
+    UnableToExchangeApiKeyError,
+    UnexpectedStatus,
+)
 
 
 def test_exchange_api_called(mocker, credentials, oauth_token):
@@ -28,14 +32,23 @@ def test_exchange_api_called(mocker, credentials, oauth_token):
     assert token.refresh_token == refresh_token
 
 
-def test_unauthorized(mocker, credentials):
+@pytest.mark.parametrize(
+    "status_code, expect_exception",
+    (
+        (400, UnableToExchangeApiKeyError),
+        (401, ApiKeyRejectedError),
+        (403, UnableToExchangeApiKeyError),
+        (500, UnexpectedStatus),
+    ),
+)
+def test_exchange_key_error(mocker, credentials, status_code, expect_exception):
     # given
     client_mock = mocker.MagicMock(spec=Client)
     request_mock = mocker.MagicMock()
     client_mock.get_httpx_client.return_value = request_mock
     request_mock.request.return_value = mocker.MagicMock()
-    request_mock.request.return_value.status_code = 401
+    request_mock.request.return_value.status_code = status_code
 
     # when
-    with pytest.raises(UnableToExchangeApiKeyError):
+    with pytest.raises(expect_exception):
         exchange_api_key(client_mock, credentials)


### PR DESCRIPTION
We now know if a token is explicitly rejected as invalid, as opposed to any other token exchange error.

This commit also removes dependency on the `backoff` package and its use when requesting token. The backoff mechanism was used only in a single place with no good justification for the discrepancy. The client libraries use their own backoff anyway, so removing this seems like a good idea.