### PR TITLE
chore: Catch errors in `_parse_response()` and re-raise them with a custom exception

### DIFF
--- a/codegen/templates/endpoint_module.py.jinja
+++ b/codegen/templates/endpoint_module.py.jinja
@@ -1,0 +1,156 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+{% for relative in endpoint.relative_imports %}
+{{ relative }}
+{% endfor %}
+
+{% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params,
+    arguments, client, kwargs, parse_response, docstring, body_to_kwarg %}
+
+{% set return_string = endpoint.response_type() %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
+
+def _get_kwargs(
+    {{ arguments(endpoint, include_client=False) | indent(4) }}
+) -> Dict[str, Any]:
+    {{ header_params(endpoint) | indent(4) }}
+
+    {{ cookie_params(endpoint) | indent(4) }}
+
+    {{ query_params(endpoint) | indent(4) }}
+
+    _kwargs: Dict[str, Any] = {
+        "method": "{{ endpoint.method }}",
+        {% if endpoint.path_parameters %}
+        "url": "{{ endpoint.path }}".format(
+        {%- for parameter in endpoint.path_parameters -%}
+        {{parameter.python_name}}={{parameter.python_name}},
+        {%- endfor -%}
+        ),
+        {% else %}
+        "url": "{{ endpoint.path }}",
+        {% endif %}
+        {% if endpoint.query_parameters %}
+        "params": params,
+        {% endif %}
+        {% if endpoint.cookie_parameters %}
+        "cookies": cookies,
+        {% endif %}
+    }
+
+{% if endpoint.bodies | length > 1 %}
+{% for body in endpoint.bodies %}
+    if isinstance(body, {{body.prop.get_type_string() }}):
+        {% set destination = "_" + body.body_type + "_body" %}
+        {{ body_to_kwarg(body, destination) | indent(8) }}
+        _kwargs["{{ body.body_type.value }}"] = {{ destination }}
+        headers["Content-Type"] = "{{ body.content_type }}"
+{% endfor %}
+{% elif endpoint.bodies | length == 1 %}
+{% set body = endpoint.bodies[0] %}
+    {{ body_to_kwarg(body, "_body") | indent(4) }}
+    _kwargs["{{ body.body_type.value }}"] = _body
+    {% if body.content_type != "multipart/form-data" %}{# Need httpx to set the boundary automatically #}
+    headers["Content-Type"] = "{{ body.content_type }}"
+    {% endif %}
+{% endif %}
+
+{% if endpoint.header_parameters or endpoint.bodies | length > 0 %}
+    _kwargs["headers"] = headers
+{% endif %}
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[{{ return_string }}]:
+    try:
+        {% for response in endpoint.responses %}
+        if response.status_code == HTTPStatus.{{ response.status_code.name }}:
+            {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
+            {% if prop_template.construct %}
+            {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
+            {% elif response.source.return_type == response.prop.get_type_string()  %}
+            {{ response.prop.python_name }} = {{ response.source.attribute }}
+            {% else %}
+            {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source.attribute }})
+            {% endif %}
+            return {{ response.prop.python_name }}
+            {% else %}
+            return None
+            {% endif %}
+        {% endfor %}
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[{{ return_string }}]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint, include_client=False) }}
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+{% if parsed_responses %}
+def sync(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return sync_detailed(
+        {{ kwargs(endpoint) }}
+    ).parsed
+{% endif %}
+
+async def asyncio_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint, include_client=False) }}
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+{% if parsed_responses %}
+async def asyncio(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return (await asyncio_detailed(
+        {{ kwargs(endpoint) }}
+    )).parsed
+{% endif %}

--- a/codegen/templates/errors.py.jinja
+++ b/codegen/templates/errors.py.jinja
@@ -15,6 +15,8 @@
 
 """Contains shared errors types that can be raised from API functions"""
 
+import httpx
+
 __all__ = [
     "UnexpectedStatus",
     "InvalidApiTokenException",
@@ -71,3 +73,11 @@ class UnableToRefreshTokenError(Exception):
 
     def __init__(self, reason: str = "Unknown") -> None:
         super().__init__(f"Unable to refresh token. Reason: {reason}")
+
+
+class UnableToParseResponse(Exception):
+    """Raise when there is an exception during parsing a response"""
+
+    def __init__(self, exception: BaseException, response: httpx.Response) -> None:
+        self.exception = exception
+        self.response = response

--- a/src/neptune_api/api/backend/exchange_api_token.py
+++ b/src/neptune_api/api/backend/exchange_api_token.py
@@ -53,29 +53,33 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, Error, NeptuneOauthToken]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = NeptuneOauthToken.from_dict(response.json())
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = NeptuneOauthToken.from_dict(response.json())
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = Error.from_dict(response.json())
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = Error.from_dict(response.json())
 
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/backend/get_client_config.py
+++ b/src/neptune_api/api/backend/get_client_config.py
@@ -66,29 +66,33 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, ClientConfig, Error]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = ClientConfig.from_dict(response.json())
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = ClientConfig.from_dict(response.json())
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = Error.from_dict(response.json())
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = Error.from_dict(response.json())
 
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/backend/get_project.py
+++ b/src/neptune_api/api/backend/get_project.py
@@ -59,29 +59,33 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, Error, ProjectDTO]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = ProjectDTO.from_dict(response.json())
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = ProjectDTO.from_dict(response.json())
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = Error.from_dict(response.json())
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = Error.from_dict(response.json())
 
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/ingestion/bulk_check_status.py
+++ b/src/neptune_api/api/ingestion/bulk_check_status.py
@@ -68,28 +68,32 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
-        response_413 = cast(Any, None)
-        return response_413
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
+            response_413 = cast(Any, None)
+            return response_413
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/ingestion/ingest.py
+++ b/src/neptune_api/api/ingestion/ingest.py
@@ -59,28 +59,32 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
-        response_413 = cast(Any, None)
-        return response_413
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
+            response_413 = cast(Any, None)
+            return response_413
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/get_attributes_with_paths_filter_proto.py
+++ b/src/neptune_api/api/retrieval/get_attributes_with_paths_filter_proto.py
@@ -73,34 +73,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/get_multiple_float_series_values_proto.py
+++ b/src/neptune_api/api/retrieval/get_multiple_float_series_values_proto.py
@@ -60,34 +60,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/get_series_values_proto.py
+++ b/src/neptune_api/api/retrieval/get_series_values_proto.py
@@ -70,34 +70,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/query_attribute_definitions_proto.py
+++ b/src/neptune_api/api/retrieval/query_attribute_definitions_proto.py
@@ -68,34 +68,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/query_attribute_definitions_within_project.py
+++ b/src/neptune_api/api/retrieval/query_attribute_definitions_within_project.py
@@ -69,34 +69,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, QueryAttributeDefinitionsResultDTO]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = QueryAttributeDefinitionsResultDTO.from_dict(response.json())
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = QueryAttributeDefinitionsResultDTO.from_dict(response.json())
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/query_attributes_within_project_proto.py
+++ b/src/neptune_api/api/retrieval/query_attributes_within_project_proto.py
@@ -69,34 +69,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/retrieval/search_leaderboard_entries_proto.py
+++ b/src/neptune_api/api/retrieval/search_leaderboard_entries_proto.py
@@ -78,34 +78,38 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, File]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = File(payload=BytesIO(response.content))
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = File(payload=BytesIO(response.content))
 
-        return response_200
-    if response.status_code == HTTPStatus.BAD_REQUEST:
-        response_400 = cast(Any, None)
-        return response_400
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.NOT_FOUND:
-        response_404 = cast(Any, None)
-        return response_404
-    if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-        response_408 = cast(Any, None)
-        return response_408
-    if response.status_code == HTTPStatus.CONFLICT:
-        response_409 = cast(Any, None)
-        return response_409
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = cast(Any, None)
-        return response_422
-    if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-        response_429 = cast(Any, None)
-        return response_429
+            return response_200
+        if response.status_code == HTTPStatus.BAD_REQUEST:
+            response_400 = cast(Any, None)
+            return response_400
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_404 = cast(Any, None)
+            return response_404
+        if response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+            response_408 = cast(Any, None)
+            return response_408
+        if response.status_code == HTTPStatus.CONFLICT:
+            response_409 = cast(Any, None)
+            return response_409
+        if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+            response_422 = cast(Any, None)
+            return response_422
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            response_429 = cast(Any, None)
+            return response_429
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/api/storage/signed_url.py
+++ b/src/neptune_api/api/storage/signed_url.py
@@ -57,19 +57,23 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[Any, CreateSignedUrlsResponse]]:
-    if response.status_code == HTTPStatus.OK:
-        response_200 = CreateSignedUrlsResponse.from_dict(response.json())
+    try:
+        if response.status_code == HTTPStatus.OK:
+            response_200 = CreateSignedUrlsResponse.from_dict(response.json())
 
-        return response_200
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(Any, None)
-        return response_401
-    if response.status_code == HTTPStatus.FORBIDDEN:
-        response_403 = cast(Any, None)
-        return response_403
-    if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
-        response_413 = cast(Any, None)
-        return response_413
+            return response_200
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            response_401 = cast(Any, None)
+            return response_401
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            response_403 = cast(Any, None)
+            return response_403
+        if response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
+            response_413 = cast(Any, None)
+            return response_413
+    except Exception as e:
+        raise errors.UnableToParseResponse(e, response) from e
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/src/neptune_api/errors.py
+++ b/src/neptune_api/errors.py
@@ -15,6 +15,8 @@
 
 """Contains shared errors types that can be raised from API functions"""
 
+import httpx
+
 __all__ = [
     "UnexpectedStatus",
     "InvalidApiTokenException",
@@ -71,3 +73,11 @@ class UnableToRefreshTokenError(Exception):
 
     def __init__(self, reason: str = "Unknown") -> None:
         super().__init__(f"Unable to refresh token. Reason: {reason}")
+
+
+class UnableToParseResponse(Exception):
+    """Raise when there is an exception during parsing a response"""
+
+    def __init__(self, exception: BaseException, response: httpx.Response) -> None:
+        self.exception = exception
+        self.response = response

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -1,0 +1,61 @@
+from http import HTTPStatus
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from neptune_api.api.backend import (
+    exchange_api_token,
+    get_client_config,
+    get_project,
+)
+from neptune_api.api.retrieval import query_attribute_definitions_within_project
+from neptune_api.errors import UnableToParseResponse
+from neptune_api.models import QueryAttributeDefinitionsBodyDTO
+
+
+# Test for invalid JSON as well as empty JSON responses -> missing fields
+@pytest.mark.parametrize("content", (b"not-json", b"{}"))
+@pytest.mark.parametrize(
+    "endpoint_module, kwargs",
+    (
+        (query_attribute_definitions_within_project, {"body": QueryAttributeDefinitionsBodyDTO()}),
+        (get_project, {"project_identifier": "some/project"}),
+        (get_client_config, {}),
+        (exchange_api_token, {"x_neptune_api_token": "some-token"}),
+    ),
+)
+def test_error_while_parsing_200_response(endpoint_module, kwargs, content):
+    httpx_client = Mock()
+    httpx_client.request.return_value = httpx.Response(status_code=HTTPStatus(200), content=content, headers={})
+
+    client = Mock()
+    client.get_httpx_client = Mock(return_value=httpx_client)
+
+    kwargs["client"] = client
+
+    with pytest.raises(UnableToParseResponse):
+        endpoint_module.sync_detailed(**kwargs)
+
+
+@pytest.mark.parametrize("content", (b"not-json", b"{}"))
+@pytest.mark.parametrize(
+    "endpoint_module, kwargs",
+    (
+        (get_project, {"project_identifier": ""}),
+        (get_client_config, {}),
+        (exchange_api_token, {"x_neptune_api_token": "some-token"}),
+    ),
+)
+def test_error_while_parsing_400_response(endpoint_module, kwargs, content):
+    """Test errors in parsing error responses, specifically 400 Bad Request -> the Error model."""
+    httpx_client = Mock()
+    httpx_client.request.return_value = httpx.Response(status_code=HTTPStatus(400), content=content, headers={})
+
+    client = Mock()
+    client.get_httpx_client = Mock(return_value=httpx_client)
+
+    kwargs["client"] = client
+
+    with pytest.raises(UnableToParseResponse):
+        endpoint_module.sync_detailed(**kwargs)


### PR DESCRIPTION
In case there was an error parsing the response (eg. invalid JSON) we could never inspect the actual response content/headers/status.
This PR wraps any errors during response parsing in a new exception that holds both the original exception, and the response that triggered the error

## Summary by Sourcery

Wrap response parsing in a try/except block and raise a custom exception when parsing fails

Enhancements:
- Wrap parsing logic in all `_parse_response` functions to catch errors and re-raise as `UnableToParseResponse`
- Introduce a new `UnableToParseResponse` exception that carries the original error and HTTP response
- Update the error template and generator to import `httpx` and include parsing error handling