### PR TITLE
chore: Call `super().__init__()` when constructing `UnableToParseResponse`

### DIFF
--- a/codegen/templates/errors.py.jinja
+++ b/codegen/templates/errors.py.jinja
@@ -23,6 +23,7 @@ __all__ = [
     "UnableToExchangeApiKeyError",
     "ApiKeyRejectedError",
     "UnableToDeserializeApiKeyError",
+    "UnableToParseResponse",
     "UnableToRefreshTokenError",
 ]
 
@@ -81,3 +82,7 @@ class UnableToParseResponse(Exception):
     def __init__(self, exception: BaseException, response: httpx.Response) -> None:
         self.exception = exception
         self.response = response
+        super().__init__(
+            f"Unable to parse server response: {exception}. "
+            f"Response: HTTP {response.status_code}: {response.content!r}"
+        )

--- a/src/neptune_api/errors.py
+++ b/src/neptune_api/errors.py
@@ -23,6 +23,7 @@ __all__ = [
     "UnableToExchangeApiKeyError",
     "ApiKeyRejectedError",
     "UnableToDeserializeApiKeyError",
+    "UnableToParseResponse",
     "UnableToRefreshTokenError",
 ]
 
@@ -81,3 +82,7 @@ class UnableToParseResponse(Exception):
     def __init__(self, exception: BaseException, response: httpx.Response) -> None:
         self.exception = exception
         self.response = response
+        super().__init__(
+            f"Unable to parse server response: {exception}. "
+            f"Response: HTTP {response.status_code}: {response.content!r}"
+        )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Call super().__init__ in UnableToParseResponse constructor to set a descriptive error message containing exception details and HTTP response.